### PR TITLE
Properly dispose of the HttpRuntime

### DIFF
--- a/src/MvcIntegrationTestFramework/Browser.cs
+++ b/src/MvcIntegrationTestFramework/Browser.cs
@@ -231,8 +231,8 @@ namespace FakeHost {
 			return form.ToString();
 		}
 
-		public void Dispose() {
-			//for future use
-		}
+        public void Dispose() {
+            _appHost.Dispose();
+        }
 	}
 }

--- a/src/MvcIntegrationTestFramework/Hosting/AppDomainProxy.cs
+++ b/src/MvcIntegrationTestFramework/Hosting/AppDomainProxy.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Web;
 using FakeHost.Browsing;
 
 namespace FakeHost.Hosting {
   /// <summary>
   /// Simply provides a remoting gateway to execute code within the ASP.NET-hosting appdomain
   /// </summary>
-  internal class AppDomainProxy : MarshalByRefObject {
+  internal class AppDomainProxy : MarshalByRefObject, IDisposable {
     public void RunCodeInAppDomain(Action codeToRun) {
       codeToRun();
     }
@@ -21,6 +22,11 @@ namespace FakeHost.Hosting {
 
     public override object InitializeLifetimeService() {
       return null; // Tells .NET not to expire this remoting object
+    }
+
+    public void Dispose()
+    {
+      HttpRuntime.Close();
     }
   }
 }

--- a/src/MvcIntegrationTestFramework/Hosting/AppHost.cs
+++ b/src/MvcIntegrationTestFramework/Hosting/AppHost.cs
@@ -11,7 +11,7 @@ namespace FakeHost.Hosting {
   /// Hosts an ASP.NET application within an ASP.NET-enabled .NET appdomain
   /// and provides methods for executing test code within that appdomain
   /// </summary>
-  internal class AppHost {
+  internal class AppHost : IDisposable {
     private readonly AppDomainProxy appDomainProxy; // The gateway to the ASP.NET-enabled .NET appdomain
 
     public AppHost(string appPhysicalDirectory)
@@ -87,5 +87,10 @@ namespace FakeHost.Hosting {
     }
 
     #endregion
+
+    public void Dispose()
+    {
+      appDomainProxy.Dispose();
+    }
   }
 }


### PR DESCRIPTION
I was having trouble with my web server continuing to run at the end of a test.  I think the right change is to call HttpRuntime.Close() when the Browser is disposed, but I'm not certain, because my understanding of this stuff is pretty primitive at the moment.
